### PR TITLE
Make std::bind usable for callbacks

### DIFF
--- a/src/EspalexaDevice.h
+++ b/src/EspalexaDevice.h
@@ -5,9 +5,9 @@
 
 typedef class EspalexaDevice;
 
-typedef void (*BrightnessCallbackFunction) (uint8_t b);
-typedef void (*DeviceCallbackFunction) (EspalexaDevice* d);
-typedef void (*ColorCallbackFunction) (uint8_t br, uint32_t col);
+typedef std::function<void(uint8_t b)> BrightnessCallbackFunction;
+typedef std::function<void(EspalexaDevice* d)> DeviceCallbackFunction;
+typedef std::function<void(uint8_t br, uint32_t col)> ColorCallbackFunction;
 
 enum class EspalexaColorMode : uint8_t { none = 0, ct = 1, hs = 2, xy = 3 };
 enum class EspalexaDeviceType : uint8_t { onoff = 0, dimmable = 1, whitespectrum = 2, color = 3, extendedcolor = 4 };


### PR DESCRIPTION
For my project I need to use a member function as a callback for Espalexa which is currently not possible. This change allows people to do something like this while the "old" callback semantics should still remain intact (so existing code does not have to changed)

```
BrightnessCallbackFunction brightnessCallback = std::bind(&ShelfWeb::_handleBrightness, this, std::placeholders::_1);
espalexa.addDevice(ShelfConfig::config.hostname, brightnessCallback, _playback.volume()*5); 
```