### PR TITLE
Correct MAC Address Formatting in Discovery Response

### DIFF
--- a/src/Espalexa.h
+++ b/src/Espalexa.h
@@ -97,10 +97,10 @@ private:
   {
     switch (t)
     {
-      case EspalexaDeviceType::dimmable:      return "Dimmable light";
-      case EspalexaDeviceType::whitespectrum: return "Color temperature light";
-      case EspalexaDeviceType::color:         return "Color light";
-      case EspalexaDeviceType::extendedcolor: return "Extended color light";
+      case EspalexaDeviceType::dimmable:      return PSTR("Dimmable light");
+      case EspalexaDeviceType::whitespectrum: return PSTR("Color temperature light");
+      case EspalexaDeviceType::color:         return PSTR("Color light");
+      case EspalexaDeviceType::extendedcolor: return PSTR("Extended color light");
       default: return "";
     }
   }
@@ -122,7 +122,8 @@ private:
     uint8_t mac[6];
     WiFi.macAddress(mac);
 
-    sprintf_P(out, PSTR("%02X:%02X:%02X:%02X:%02X:%02X:00:11-%02X"), mac[0],mac[1],mac[2],mac[3],mac[4],mac[5], idx);
+    // sprintf_P(out, PSTR("%02X:%02X:%02X:%02X:%02X:%02X:00:11-%02X"), mac[0],mac[1],mac[2],mac[3],mac[4],mac[5], idx);
+    sprintf_P(out, PSTR("%02X:%02X:%02X:%02X:%02X:%02X-%02X-00:11"), mac[0], mac[1], mac[2], mac[3], mac[4], mac[5], idx);
   }
 
   // construct 'globally unique' Json dict key fitting into signed int


### PR DESCRIPTION
This update modifies the MAC address format in the discovery response to ensure compatibility with all devices in ESPAlexa. The previous format appended 00:11-%02X at the end, while the new format correctly places the 00:11 segment at the end, ensuring proper parsing by Alexa.

```cpp
// Old format (caused discovery issues)
sprintf_P(out, PSTR("%02X:%02X:%02X:%02X:%02X:%02X:00:11-%02X"), mac[0],mac[1],mac[2],mac[3],mac[4],mac[5], idx);

// New format (fixes discovery)
sprintf_P(out, PSTR("%02X:%02X:%02X:%02X:%02X:%02X-%02X-00:11"), mac[0], mac[1], mac[2], mac[3], mac[4], mac[5], idx);
```

✅ Fixes: Resolves the discovery issue in ESPAlexa, ensuring all devices are correctly recognized.
🔍 Tested on: Multiple Alexa devices, working as expected.