### PR TITLE
Fix stray % in JSON string

### DIFF
--- a/src/Espalexa.h
+++ b/src/Espalexa.h
@@ -166,7 +166,7 @@ private:
     if (static_cast<uint8_t>(dev->getType()) == 0)
     {
        // On/Off
-        sprintf_P(buf, PSTR("{\"state\":{\"on\":%s,\"alert\":\"none%\",\"reachable\":true},"
+        sprintf_P(buf, PSTR("{\"state\":{\"on\":%s,\"alert\":\"none\",\"reachable\":true},"
                        "\"type\":\"%s\",\"name\":\"%s\",\"modelid\":\"%s\",\"manufacturername\":\"Philips\",\"uniqueid\":\"%s\",\"swversion\":\"espalexa-2.7.0\"}")
                       
         , (dev->getValue())?"true":"false", typeString(dev->getType()),


### PR DESCRIPTION
@jeronimonunes spotted a stray % in the JSON on/off string in #217.

This PR fixes that.